### PR TITLE
Added get_dataset_osx.sh

### DIFF
--- a/dl_assignment1/cs231n/datasets/get_dataset_osx.sh
+++ b/dl_assignment1/cs231n/datasets/get_dataset_osx.sh
@@ -1,0 +1,5 @@
+
+# Get CIFAR10
+curl -O http://www.cs.toronto.edu/~kriz/cifar-10-python.tar.gz
+tar -xzvf cifar-10-python.tar.gz
+rm cifar-10-python.tar.gz 


### PR DESCRIPTION
The command 'wget' works not very well on osx. And the substitution is using 'curl -O' to download files.